### PR TITLE
fix: add missing relations in models

### DIFF
--- a/app/models/passenger_request.rb
+++ b/app/models/passenger_request.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class PassengerRequest < ApplicationRecord
+  belongs_to :trip
+  belongs_to :user
 end


### PR DESCRIPTION
Se agrega la relación belongs to en el modelo de passenger requests para generar la conexión entre trips y users