### PR TITLE
fix: fix overflow problem in trip cards

### DIFF
--- a/app/javascript/components/TripCard.js
+++ b/app/javascript/components/TripCard.js
@@ -22,7 +22,7 @@ const TripCard = (props) => {
       </div>
       <div className="card-content p-0">
         <div className="media">
-          <div className="media-content">
+          <div className="media-content" style={{overflowX: 'unset'}}>
             <div className="columns is-multiline is-mobile">
               <div className="column is-half pb-0">
                 <p className="subtitle is-6">


### PR DESCRIPTION
Se arregla el problema de que se cortaba la información del viaje en las tarjetas con información del viaje.
<img width="359" alt="Captura de Pantalla 2022-05-29 a la(s) 17 50 22" src="https://user-images.githubusercontent.com/37166902/170892636-7026f4da-64cd-464b-a8a6-d53be02a89c5.png">