### PR TITLE
fix: change mailer from gmail to mailgun

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ DATABASE_URL=postgres://user:password@db-test:5432/database
 
 Se debe crear un archivo config/local_env.yml cuyo contenido debe verse así:
 ```
-GMAIL_USERNAME: 'mail'
-GMAIL_PASSWORD: 'password'
+MAIL_USERNAME: 'mail'
+MAIL_PASSWORD: 'password'
 ```
 donde 'mail' es el mail de la organización y password su contraseña.
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,11 +85,11 @@ Rails.application.configure do
     port: 3000
     }
   config.action_mailer.smtp_settings = {
-    :address => "smtp.gmail.com",
+    :address => "smtp.mailgun.org",
     :port => 587,
-    :domain => 'gmail',
-    :user_name => ENV["GMAIL_USERNAME"],
-    :password => ENV["GMAIL_PASSWORD"],
+    :domain => 'car-pou.tech.mailgun.org',
+    :user_name => ENV["MAIL_USERNAME"],
+    :password => ENV["MAIL_PASSWORD"],
     :authentication => 'plain',
     :enable_starttls_auto => true,
     :openssl_verify_mode => 'none' 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'carpou@car-pou.tech'
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'CarpouDeviseMailer'


### PR DESCRIPTION
Se cambia la configuración del mailer que usaba gmail para ahora usar mailgun, debido a un cambio en la política de google que ya no permitía usar gmail com smtp.

El único cambio que hay que hacer es cambiar las credenciales del env, más detalles en el readme